### PR TITLE
Revise Kafka table creation examples in documentation

### DIFF
--- a/draft-netana-nmop-yang-message-broker-message-key-02.txt
+++ b/draft-netana-nmop-yang-message-broker-message-key-02.txt
@@ -648,14 +648,6 @@ Internet-Draft              YANG Message Keys              December 2025
    ClickHouse integrates with Message Brokers through Integration
    Table Engines.
 
-   Here is a Data Definition Language example:
-
-   CREATE TABLE queue (
-      timestamp UInt64,
-      level String,
-      message String
-   ) ENGINE = Kafka('localhost:9092', 'topic', 'group1', 'JSONEachRow');
-
    Reading (selecting) data through Kafka Table Engine follows Kafka
    semantics of advancing the offset, so subsequent reads will start at
    the offset the previous read left off.
@@ -666,6 +658,19 @@ Internet-Draft              YANG Message Keys              December 2025
    *  Use the engine to create a Kafka consumer and consider it a data
       stream.
 
+Example:
+
+CREATE TABLE queue (
+    timestamp UInt64,
+    level String,
+    message String
+) 
+ENGINE = Kafka 
+SETTINGS kafka_broker_list = 'localhost:9092',
+    kafka_topic_list = 'topic',
+    kafka_group_name = 'group1',
+    kafka_format = 'JSONEachRow',
+    kafka_num_consumers = 4;
 
 
 
@@ -676,11 +681,46 @@ Internet-Draft              YANG Message Keys              December 2025
 
    *  Create a table with the desired structure.
 
+Example:
+
+CREATE TABLE messages (
+    key String,
+    timestamp UInt64,
+    level String,
+    message String
+) 
+ENGINE = MergeTree
+ORDER BY (key, timestamp);
+
    *  Create a materialized view that converts data from the engine and
       puts it into a previously created table.
 
+CREATE MATERIALIZED VIEW mv_messages TO messages AS
+SELECT
+    _key AS key,
+    timestamp,
+    level,
+    message
+FROM queue;
+
    The message key and partition ID are available as virtual (read only)
    columns _key and _partition.
+
+5.1.3. Message Formats
+
+ClickHouse supports numerous message formats natively. The example above
+uses the JSON Lines format but other (binary) formats, such as Avro or
+Protobuf, are supported as well.
+
+5.1.4. Schema Registry
+
+ClickHouse has built in schema registry support. For Avro, the schema 
+registry and authentication are encoded in additional parameters to
+the Kafka consumer.
+
+For formats such as Confluent JSON_SR, use the kafka_schema_registry_skip_bytes
+parameter to skip reading the schema registry preamble. The schema can
+then be encoded explicitly.
 
 6.  IANA Considerations
 


### PR DESCRIPTION
Updated DDL examples for Kafka integration in ClickHouse, including table creation and materialized view.